### PR TITLE
Generate pointer types for required & optional attributes

### DIFF
--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -79,8 +79,7 @@ func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
 	if err := json.TFParser.Unmarshal(attrs, params); err != nil {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
-	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard),
-	    resource.WithZeroElemPtrFilter(resource.CNameWildcard)}
+	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
 	{{ range .LateInitializer.IgnoredFields -}}
 	    opts = append(opts, resource.WithNameFilter("{{ . }}"))
 	{{ end }}

--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -22,11 +22,10 @@ import (
 	"go/types"
 	"sort"
 
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	twtypes "github.com/muvaf/typewriter/pkg/types"
 	"github.com/pkg/errors"
-
-	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
 
 	"github.com/crossplane-contrib/terrajet/pkg/config"
 	"github.com/crossplane-contrib/terrajet/pkg/types/comments"


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #88

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Example struct fields generated before this change in `provider-tf-azure` for `v1alpha1.KubernetesCluster` MR:
![image](https://user-images.githubusercontent.com/9376684/136439578-4f1cf271-f3d8-4608-bc0c-acc6a03a9ff9.png)

And with this change, the type of the field corresponding to the required `network_plugin` attribute becomes:
![image](https://user-images.githubusercontent.com/9376684/136439702-2b0de1eb-efa3-427f-a672-e0cdc48afbde.png)

Successfully tested (provisioned/deprovisioned) `provider-tf-azure` `KubernetesCluster`, `PostgresqlServer` and `VirtualNetwork` resources (with custom configurations) generated with this PR.


[contribution process]: https://git.io/fj2m9
