### PR TITLE
Allow prevent_destroy meta-arg to be overridden per resource

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -212,6 +212,12 @@ type Resource struct {
 	// databases.
 	UseAsync bool
 
+	// AllowDestroy controls whether the `prevent_destroy: true` stanza
+	// is included in the Terraform configuration for the resource.
+	// For certain resources like Azure's PostgreSQLConfiguration,
+	// we would like to allow replacement.
+	AllowDestroy bool
+
 	// ExternalName allows you to specify a custom ExternalName.
 	ExternalName ExternalName
 

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -181,7 +181,7 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 
 	return managed.ExternalObservation{
 		ResourceExists:          true,
-		ResourceUpToDate:        plan.UpToDate,
+		ResourceUpToDate:        plan.UpToDate && plan.Exists,
 		ResourceLateInitialized: lateInitedAnn || lateInitedParams,
 		ConnectionDetails:       conn,
 	}, nil

--- a/pkg/terraform/files.go
+++ b/pkg/terraform/files.go
@@ -148,7 +148,7 @@ func (fp *FileProducer) WriteMainTF() error {
 	// If the resource is in a deletion process, we need to remove the deletion
 	// protection.
 	fp.parameters["lifecycle"] = map[string]bool{
-		"prevent_destroy": !meta.WasDeleted(fp.Resource),
+		"prevent_destroy": !meta.WasDeleted(fp.Resource) && !fp.Config.AllowDestroy,
 	}
 	// Note(turkenh): To use third party providers, we need to configure
 	// provider name in required_providers.


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #158

For certain Terraform resources like Azure's PostgreSQL server configuration, we should not be including the `lifecycle.prevent_destroy` meta-arg for updates. This PR proposes a backwards-compatible change that allows us to override this behavior. The default behavior stays the same, unless explicitly configured for a resource, we always include (apart from deletions) the `prevent_destroy: true` meta-argument in the generated configuration.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested using the example manifest of PostgreSQLConfiguration resource of `provider-jet-azure` on top of https://github.com/crossplane-contrib/provider-jet-azure/pull/98.

[contribution process]: https://git.io/fj2m9
