### PR TITLE
Add fake utility for cli calls

### DIFF
--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/terrajet/pkg/config"
+	"github.com/crossplane-contrib/terrajet/pkg/exec"
 	"github.com/crossplane-contrib/terrajet/pkg/resource"
 	"github.com/crossplane-contrib/terrajet/pkg/resource/json"
 	"github.com/crossplane-contrib/terrajet/pkg/terraform"
@@ -98,7 +99,7 @@ func (c *Connector) Connect(ctx context.Context, mg xpresource.Managed) (managed
 		return nil, errors.Wrap(err, errGetWorkspace)
 	}
 
-	tf.Executor = &terraform.RealExec{}
+	tf.Executor = &exec.OsExec{}
 
 	return &external{
 		workspace: tf,

--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -98,6 +98,8 @@ func (c *Connector) Connect(ctx context.Context, mg xpresource.Managed) (managed
 		return nil, errors.Wrap(err, errGetWorkspace)
 	}
 
+	tf.Executor = &terraform.RealExec{}
+
 	return &external{
 		workspace: tf,
 		config:    c.config,

--- a/pkg/exec/exec.go
+++ b/pkg/exec/exec.go
@@ -14,43 +14,71 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package terraform
+package exec
 
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 )
 
 // Exec interface provides a Command interface. By this way, real or fake implementation of functions is determined.
 type Exec interface {
-	CommandContext(ctx context.Context, name string, dir string, env []string, arg ...string) Command
+	CommandContext(ctx context.Context, name string, arg ...string) Command
+	SetEnv(env []string)
+	SetDir(dir string)
 }
 
-// RealExec struct implements the CommandContext function that calls the function from the exec package.
-type RealExec struct{}
+// OsExec struct implements the CommandContext function that calls the function from the exec package.
+type OsExec struct {
+	dir string
+	env []string
+}
+
+// SetDir lets you set the dir of OsExec.
+func (r *OsExec) SetDir(dir string) {
+	r.dir = dir
+}
+
+// SetEnv lets you set the env of OsExec.
+func (r *OsExec) SetEnv(env []string) {
+	r.env = env
+}
 
 // CommandContext calls the function from exec package, then configure the *Cmd object with `dir` and `env`.
 // It returns a *Cmd object thus, the real implementation of CombinedOutput will be called.
-func (r *RealExec) CommandContext(ctx context.Context, name string, dir string, env []string, arg ...string) Command {
+func (r *OsExec) CommandContext(ctx context.Context, name string, arg ...string) Command {
 	cmd := exec.CommandContext(ctx, name, arg...)
 
-	configureCmd(cmd, dir, env)
+	configureCmd(cmd, r.dir, r.env)
 
 	return cmd
 }
 
 // FakeExec struct implements the CommandContext function that calls fake one.
 type FakeExec struct {
+	dir    string
+	env    []string
 	stdErr []byte
 	stdOut []byte
 	err    error
 }
 
+// SetDir lets you set the dir of FakeExec.
+func (m *FakeExec) SetDir(dir string) {
+	m.dir = dir
+}
+
+// SetEnv lets you set the env of FakeExec.
+func (m *FakeExec) SetEnv(env []string) {
+	m.env = env
+}
+
 // CommandContext function manipulates the `StdErr` and `stdOut` .
 // It returns a FakeCommand object thus, the fake implementation of CombinedOutput will be called.
-func (m *FakeExec) CommandContext(_ context.Context, _ string, _ string, _ []string, _ ...string) Command {
+func (m *FakeExec) CommandContext(_ context.Context, _ string, _ ...string) Command {
 	b := bytes.Buffer{}
 
 	if m.stdOut != nil {
@@ -80,6 +108,41 @@ type Command interface {
 type FakeCommand struct {
 	out []byte
 	err error
+}
+
+// FakeCommandOption lets you configure the FakeCommand.
+type FakeCommandOption func(f *FakeCommand)
+
+// WithStdOut lets you set the stdOut of FakeCommand.
+func WithStdOut(stdOut string) FakeCommandOption {
+	return func(f *FakeCommand) {
+		f.out = []byte(stdOut)
+	}
+}
+
+// WithStdErr lets you set the stdErr of FakeCommand.
+func WithStdErr(stdErr string) FakeCommandOption {
+	return func(f *FakeCommand) {
+		f.out = []byte(stdErr)
+	}
+}
+
+// WithErr lets you set the error of FakeCommand.
+func WithErr(err string) FakeCommandOption {
+	return func(f *FakeCommand) {
+		f.err = errors.New(err)
+	}
+}
+
+// NewFakeCommand returns a new FakeCommand.
+func NewFakeCommand(opts ...FakeCommandOption) *FakeCommand {
+	f := &FakeCommand{}
+
+	for _, o := range opts {
+		o(f)
+	}
+
+	return f
 }
 
 // CombinedOutput returns the output and error.

--- a/pkg/terraform/exec.go
+++ b/pkg/terraform/exec.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terraform
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+)
+
+// Exec interface provides a Command interface. By this way, real or fake implementation of functions is determined.
+type Exec interface {
+	CommandContext(ctx context.Context, name string, dir string, env []string, arg ...string) Command
+}
+
+// RealExec struct implements the CommandContext function that calls the function from the exec package.
+type RealExec struct{}
+
+// CommandContext calls the function from exec package, then configure the *Cmd object with `dir` and `env`.
+// It returns a *Cmd object thus, the real implementation of CombinedOutput will be called.
+func (r *RealExec) CommandContext(ctx context.Context, name string, dir string, env []string, arg ...string) Command {
+	cmd := exec.CommandContext(ctx, name, arg...)
+
+	configureCmd(cmd, dir, env)
+
+	return cmd
+}
+
+// FakeExec struct implements the CommandContext function that calls fake one.
+type FakeExec struct {
+	stdErr []byte
+	stdOut []byte
+	err    error
+}
+
+// CommandContext function manipulates the `StdErr` and `stdOut` .
+// It returns a FakeCommand object thus, the fake implementation of CombinedOutput will be called.
+func (m *FakeExec) CommandContext(_ context.Context, _ string, _ string, _ []string, _ ...string) Command {
+	b := bytes.Buffer{}
+
+	if m.stdOut != nil {
+		if _, err := b.Write(m.stdOut); err != nil {
+			panic(err)
+		}
+	}
+
+	if m.stdErr != nil {
+		if _, err := b.Write(m.stdErr); err != nil {
+			panic(err)
+		}
+	}
+
+	return &FakeCommand{
+		out: b.Bytes(),
+		err: m.err,
+	}
+}
+
+// Command interface
+type Command interface {
+	CombinedOutput() ([]byte, error)
+}
+
+// FakeCommand struct implements the CombinedOutput function that calls fake one.
+type FakeCommand struct {
+	out []byte
+	err error
+}
+
+// CombinedOutput returns the output and error.
+func (c *FakeCommand) CombinedOutput() ([]byte, error) {
+	return c.out, c.err
+}
+
+func configureCmd(cmd *exec.Cmd, dir string, env []string) {
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+
+	cmd.Env = append(cmd.Env, env...)
+	cmd.Dir = dir
+}


### PR DESCRIPTION
### Description of your changes

Fixes #81 

This PR adds a utility for the command calls. There are two interfaces to manage the command and command outputs. 

Mock tests can be written by using this utility. `StdErr` and `StdOut` values can be manipulated via `FakeExec` struct that implements the Fake call of the `CombinedOutput` function.

In [real CombinedOutput] function, the StdErr and StdOut values are assigned to the same bytes.Buffer instance. Therefore, I also tried to implement the same logic in this [PR].

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested 

This PR was tested by adding a toy test to observe the fake functions are working properly.

[contribution process]: https://git.io/fj2m9
[real CombinedOutput]: https://github.com/golang/go/blob/1ea4d3b91164fb08b7022958b6cd8e290f12e017/src/os/exec/exec.go#L564
[PR]: https://github.com/sergenyalcin/terrajet/blob/11db5953e1b20eb63581b5e0dc584dc35d851a3c/pkg/terraform/exec.go#L48