### PR TITLE
Assume string type for unset Set/List/Map element types

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -283,6 +283,10 @@ func (g *Builder) buildSchema(sch *schema.Schema, cfg *config.Resource, tfPath [
 				}
 				elemType = paramType
 			}
+		// if unset
+		// see: https://github.com/crossplane/terrajet/issues/177
+		case nil:
+			elemType = types.Universe.Lookup("string").Type()
 		default:
 			return nil, errors.Errorf("element type of %s should be either schema.Resource or schema.Schema", fieldPath(names))
 		}


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #177 

Assume that an unset Terraform List/Set/Map element schema is of string type. Please refer to #177 for more context.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with https://github.com/crossplane-contrib/provider-jet-mongodbatlas

[contribution process]: https://git.io/fj2m9
