### PR TITLE
Add unit tests for builder

### DIFF
--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -17,13 +17,17 @@
 package types
 
 import (
+	"fmt"
 	"go/token"
 	"go/types"
 	"testing"
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
+
+	"github.com/crossplane/terrajet/pkg/config"
 )
 
 func TestBuilder_generateTypeName(t *testing.T) {
@@ -194,6 +198,201 @@ func TestBuilder_generateTypeName(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.out, got); diff != "" {
 				t.Errorf("generateTypeName(...) out = %v, want %v", got, tc.want.out)
+			}
+		})
+	}
+}
+
+func TestBuild(t *testing.T) {
+	type args struct {
+		cfg *config.Resource
+	}
+	type want struct {
+		forProvider string
+		atProvider  string
+		err         error
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Base_Types": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"id": {
+								Type:     schema.TypeInt,
+								Required: true,
+							},
+							"enable": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								Computed: true,
+							},
+							"value": {
+								Type:     schema.TypeFloat,
+								Optional: false,
+								Computed: true,
+							},
+							"config": {
+								Type:     schema.TypeString,
+								Optional: false,
+								Computed: true,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				forProvider: `type example.Parameters struct{Enable *bool "json:\"enable,omitempty\" tf:\"enable,omitempty\""; ID *int64 "json:\"id\" tf:\"id,omitempty\""; Name *string "json:\"name\" tf:\"name,omitempty\""}`,
+				atProvider:  `type example.Observation struct{Config *string "json:\"config,omitempty\" tf:\"config,omitempty\""; Value *float64 "json:\"value,omitempty\" tf:\"value,omitempty\""}`,
+			},
+		},
+		"Resource_Types": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"list": {
+								Type:     schema.TypeList,
+								Required: true,
+								Elem: &schema.Schema{
+									Type:     schema.TypeString,
+									Required: true,
+								},
+							},
+							"resource_in": {
+								Type:     schema.TypeMap,
+								Required: true,
+								Elem:     &schema.Resource{},
+							},
+							"resource_out": {
+								Type:     schema.TypeMap,
+								Optional: false,
+								Computed: true,
+								Elem:     &schema.Resource{},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				forProvider: `type example.Parameters struct{List []*string "json:\"list\" tf:\"list,omitempty\""; ResourceIn map[string]example.ResourceInParameters "json:\"resourceIn\" tf:\"resource_in,omitempty\""}`,
+				atProvider:  `type example.Observation struct{ResourceOut map[string]example.ResourceOutObservation "json:\"resourceOut,omitempty\" tf:\"resource_out,omitempty\""}`,
+			},
+		},
+		"Sensitive_Fields": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key_1": {
+								Type:      schema.TypeString,
+								Optional:  true,
+								Sensitive: true,
+							},
+							"key_2": {
+								Type:      schema.TypeString,
+								Sensitive: true,
+							},
+							"key_3": {
+								Type:      schema.TypeList,
+								Sensitive: true,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				forProvider: `type example.Parameters struct{Key1SecretRef *github.com/crossplane/crossplane-runtime/apis/common/v1.SecretKeySelector "json:\"key1SecretRef,omitempty\" tf:\"-\""; Key2SecretRef github.com/crossplane/crossplane-runtime/apis/common/v1.SecretKeySelector "json:\"key2SecretRef\" tf:\"-\""; Key3SecretRef []github.com/crossplane/crossplane-runtime/apis/common/v1.SecretKeySelector "json:\"key3SecretRef\" tf:\"-\""}`,
+				atProvider:  `type example.Observation struct{}`,
+			},
+		},
+		"Invalid_Sensitive_Fields": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key_1": {
+								Type:      schema.TypeFloat,
+								Sensitive: true,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrapf(fmt.Errorf(`got type %q for field %q, only types "string", "*string", []string and []*string supported as sensitive`, "*float64", "Key1"), "cannot build the Types"),
+			},
+		},
+		"References": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+							"reference_id": {
+								Type:     schema.TypeString,
+								Required: true,
+							},
+						},
+					},
+					References: map[string]config.Reference{
+						"reference_id": {
+							Type:         "string",
+							RefFieldName: "ExternalResourceID",
+						},
+					},
+				},
+			},
+			want: want{
+				forProvider: `type example.Parameters struct{Name *string "json:\"name\" tf:\"name,omitempty\""; ReferenceID *string "json:\"referenceId,omitempty\" tf:\"reference_id,omitempty\""; ExternalResourceID *github.com/crossplane/crossplane-runtime/apis/common/v1.Reference "json:\"externalResourceId,omitempty\" tf:\"-\""; ReferenceIDSelector *github.com/crossplane/crossplane-runtime/apis/common/v1.Selector "json:\"referenceIdSelector,omitempty\" tf:\"-\""}`,
+				atProvider:  `type example.Observation struct{}`,
+			},
+		},
+		"Invalid_Schema_Type": {
+			args: args{
+				cfg: &config.Resource{
+					TerraformResource: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"name": {
+								Type:     schema.TypeInvalid,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrapf(errors.Wrapf(errors.Errorf("invalid schema type %s", "TypeInvalid"), "cannot infer type from schema of field %s", "name"), "cannot build the Types"),
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			builder := NewBuilder(types.NewPackage("example", ""))
+			g, err := builder.Build(tc.cfg)
+
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Fatalf("Build(...): -want error, +got error: %s", diff)
+			}
+			if g.ForProviderType != nil {
+				if diff := cmp.Diff(tc.want.forProvider, g.ForProviderType.Obj().String(), test.EquateErrors()); diff != "" {
+					t.Fatalf("Build(...): -want forProvider, +got forProvider: %s", diff)
+				}
+			}
+			if g.AtProviderType != nil {
+				if diff := cmp.Diff(tc.want.atProvider, g.AtProviderType.Obj().String(), test.EquateErrors()); diff != "" {
+					t.Fatalf("Build(...): -want atProvider, +got atProvider: %s", diff)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Description of your changes

Fixes #17 

This PR adds unit tests for the resource builder. It seems that, there is not functions to compare fields one by one. Therefore, serialized strings are used in comparison.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
