### PR TITLE
controller: set external name to its latest value no matter what

### DIFF
--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -146,9 +146,9 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set observation")
 	}
 
-	lateInitedAnn, err := resource.LateInitializeAnnotations(tr, e.config, tfstate, string(res.State.GetPrivateRaw()))
+	annotationsUpdated, err := resource.SetCriticalAnnotations(tr, e.config, tfstate, string(res.State.GetPrivateRaw()))
 	if err != nil {
-		return managed.ExternalObservation{}, errors.Wrap(err, "cannot late initialize annotations")
+		return managed.ExternalObservation{}, errors.Wrap(err, "cannot set critical annotations")
 	}
 	conn, err := resource.GetConnectionDetails(tfstate, tr, e.config)
 	if err != nil {
@@ -165,7 +165,7 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 			ResourceExists:          true,
 			ResourceUpToDate:        true,
 			ConnectionDetails:       conn,
-			ResourceLateInitialized: lateInitedAnn,
+			ResourceLateInitialized: annotationsUpdated,
 		}, nil
 	}
 
@@ -182,7 +182,7 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 	return managed.ExternalObservation{
 		ResourceExists:          true,
 		ResourceUpToDate:        plan.UpToDate,
-		ResourceLateInitialized: lateInitedAnn || lateInitedParams,
+		ResourceLateInitialized: annotationsUpdated || lateInitedParams,
 		ConnectionDetails:       conn,
 	}, nil
 }
@@ -210,8 +210,8 @@ func (e *external) Create(ctx context.Context, mg xpresource.Managed) (managed.E
 	}
 
 	// NOTE(muvaf): Only spec and metadata changes are saved after Create call.
-	_, err = resource.LateInitializeAnnotations(tr, e.config, tfstate, string(res.State.GetPrivateRaw()))
-	return managed.ExternalCreation{ConnectionDetails: conn}, errors.Wrap(err, "cannot late initialize annotations")
+	_, err = resource.SetCriticalAnnotations(tr, e.config, tfstate, string(res.State.GetPrivateRaw()))
+	return managed.ExternalCreation{ConnectionDetails: conn}, errors.Wrap(err, "cannot set critical annotations")
 }
 
 func (e *external) Update(ctx context.Context, mg xpresource.Managed) (managed.ExternalUpdate, error) {


### PR DESCRIPTION


### Description of your changes

It's up to discussion whether there should be a re-creation behavior but until that lands, we'll conform to how native controllers behave and override existing external name if we have another, like the case where VPC is deleted in the console and we re-create it since its query returns 404.

Fixes https://github.com/crossplane/terrajet/issues/122

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Not yet.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
