### PR TITLE
Tagging Convention

### DIFF
--- a/pkg/config/resource.go
+++ b/pkg/config/resource.go
@@ -22,6 +22,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 )
 
 // SetIdentifierArgumentsFn sets the name of the resource in Terraform attributes map,
@@ -195,6 +198,9 @@ type OperationTimeouts struct {
 	Delete time.Duration
 }
 
+// InitializerFn returns the Initializer with a client.
+type InitializerFn func(client client.Client) managed.Initializer
+
 // Resource is the set of information that you can override at different steps
 // of the code generation pipeline.
 type Resource struct {
@@ -222,6 +228,8 @@ type Resource struct {
 	// takes more than 1 minute to complete such as Kubernetes clusters or
 	// databases.
 	UseAsync bool
+
+	Initializers []InitializerFn
 
 	// OperationTimeouts allows configuring resource operation timeouts.
 	OperationTimeouts OperationTimeouts

--- a/pkg/config/resource_test.go
+++ b/pkg/config/resource_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/crossplane/crossplane-runtime/pkg/errors"
+	"github.com/crossplane/crossplane-runtime/pkg/fieldpath"
+	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/crossplane-runtime/pkg/resource/fake"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+)
+
+const (
+	kind     = "ACoolService"
+	name     = "example-service"
+	provider = "ACoolProvider"
+)
+
+func TestTagger_Initialize(t *testing.T) {
+	errBoom := errors.New("boom")
+
+	type args struct {
+		mg   xpresource.Managed
+		kube client.Client
+	}
+	type want struct {
+		err error
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Successful": {
+			args: args{
+				mg:   &fake.Managed{},
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(nil)},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"Failure": {
+			args: args{
+				mg:   &fake.Managed{},
+				kube: &test.MockClient{MockUpdate: test.NewMockUpdateFn(errBoom)},
+			},
+			want: want{
+				err: errBoom,
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			tagger := NewTagger(tc.kube, "tags")
+			gotErr := tagger.Initialize(context.TODO(), tc.mg)
+			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("generateTypeName(...): -want error, +got error: %s", diff)
+			}
+		})
+	}
+}
+
+func TestSetExternalTagsWithPaved(t *testing.T) {
+	type args struct {
+		externalTags map[string]string
+		paved        *fieldpath.Paved
+		fieldName    string
+	}
+	type want struct {
+		pavedString string
+		err         error
+	}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"Successful": {
+			args: args{
+				externalTags: map[string]string{
+					xpresource.ExternalResourceTagKeyKind:     kind,
+					xpresource.ExternalResourceTagKeyName:     name,
+					xpresource.ExternalResourceTagKeyProvider: provider,
+				},
+				paved:     fieldpath.Pave(map[string]interface{}{}),
+				fieldName: "tags",
+			},
+			want: want{
+				pavedString: fmt.Sprintf(`{"spec":{"forProvider":{"tags":{"%s":"%s","%s":"%s","%s":"%s"}}}}`,
+					xpresource.ExternalResourceTagKeyKind, kind,
+					xpresource.ExternalResourceTagKeyName, name,
+					xpresource.ExternalResourceTagKeyProvider, provider),
+			},
+		},
+	}
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			gotByte, gotErr := setExternalTagsWithPaved(tc.externalTags, tc.paved, tc.fieldName)
+			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
+				t.Fatalf("generateTypeName(...): -want error, +got error: %s", diff)
+			}
+			if diff := cmp.Diff(tc.want.pavedString, string(gotByte), test.EquateErrors()); diff != "" {
+				t.Fatalf("generateTypeName(...): -want gotByte, +got gotByte: %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -63,7 +63,7 @@ func (cg *ControllerGenerator) Generate(cfg *config.Resource, typesPkgPath strin
 		"TypePackageAlias":       ctrlFile.Imports.UsePackage(typesPkgPath),
 		"UseAsync":               cfg.UseAsync,
 		"ResourceType":           cfg.Name,
-		"Initializers":           cfg.Initializers,
+		"Initializers":           cfg.InitializerFns,
 	}
 
 	filePath := filepath.Join(cg.ControllerGroupDir, strings.ToLower(cfg.Kind), "zz_controller.go")

--- a/pkg/pipeline/controller.go
+++ b/pkg/pipeline/controller.go
@@ -63,6 +63,7 @@ func (cg *ControllerGenerator) Generate(cfg *config.Resource, typesPkgPath strin
 		"TypePackageAlias":       ctrlFile.Imports.UsePackage(typesPkgPath),
 		"UseAsync":               cfg.UseAsync,
 		"ResourceType":           cfg.Name,
+		"Initializers":           cfg.Initializers,
 	}
 
 	filePath := filepath.Join(cg.ControllerGroupDir, strings.ToLower(cfg.Kind), "zz_controller.go")

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -26,12 +26,15 @@ import (
 // Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind.String())
-	{{- if .Initializers }}
 	var initializers managed.InitializerChain
-	for _, i := range cfg.Resources["{{ .ResourceType }}"].Initializers {
+	{{- if .Initializers }}
+	for _, i := range cfg.Resources["{{ .ResourceType }}"].InitializerFns {
 	    initializers = append(initializers,i(mgr.GetClient()))
-    }
-    {{- end}}
+	}
+	{{- end}}
+	{{- if not .DisableNameInitializer }}
+	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
+	{{- end}}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["{{ .ResourceType }}"],
@@ -43,13 +46,7 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
-		{{- if .Initializers }}
 		managed.WithInitializers(initializers),
-		{{else}}
-		{{- if .DisableNameInitializer }}
-		managed.WithInitializers(),
-		{{- end}}
-		{{- end}}
 		)
 
 	return ctrl.NewControllerManagedBy(mgr).

--- a/pkg/pipeline/templates/controller.go.tmpl
+++ b/pkg/pipeline/templates/controller.go.tmpl
@@ -26,6 +26,12 @@ import (
 // Setup adds a controller that reconciles {{ .CRD.Kind }} managed resources.
 func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terraform.SetupFn, ws *terraform.WorkspaceStore, cfg *tjconfig.Provider, concurrency int) error {
 	name := managed.ControllerName({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind.String())
+	{{- if .Initializers }}
+	var initializers managed.InitializerChain
+	for _, i := range cfg.Resources["{{ .ResourceType }}"].Initializers {
+	    initializers = append(initializers,i(mgr.GetClient()))
+    }
+    {{- end}}
 	r := managed.NewReconciler(mgr,
 		xpresource.ManagedKind({{ .TypePackageAlias }}{{ .CRD.Kind }}_GroupVersionKind),
 		managed.WithExternalConnecter(tjcontroller.NewConnector(mgr.GetClient(), ws, s, cfg.Resources["{{ .ResourceType }}"],
@@ -37,8 +43,12 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, s terra
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(terraform.NewWorkspaceFinalizer(ws, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
 		managed.WithTimeout(3*time.Minute),
+		{{- if .Initializers }}
+		managed.WithInitializers(initializers),
+		{{else}}
 		{{- if .DisableNameInitializer }}
 		managed.WithInitializers(),
+		{{- end}}
 		{{- end}}
 		)
 


### PR DESCRIPTION
### Description of your changes

Fixes https://github.com/crossplane-contrib/provider-jet-aws/issues/136

This PR provides support for tagging convention for all providers in a generic way. By this implementation, custom initializers can be set.

A new configuration field, `Initializers`, was added. The type of this field is `[]InitializerFn`:

```
// InitializerFn returns the Initializer with a client.
type InitializerFn func(client client.Client) managed.Initializer
```

The field that is expected to be set has been implemented configurable on the basis of resource.

If the `Initializers` field is not set in the resource configuration, the initializers will not be generated in controllers in `Setup` function.

In three providers (aws, azure and gcp), a defaulting is not implemented for tag fields. Some statistics were collected to decide the topic:

AWS: 761 Generated Resource / 398 Resources has not "tags" field / 1 resource's "tags" field has different type (not map[string]*string)

Azure: 645 Generated Resource / 401 Resources has not "tags" field / 2 resources' "tags" field has different type (not map[string]*string)

Google: 436 Generated Resource / 376 Resources has not "labels" field / 2 resources' "labels" field has different type (not map[string]*string)

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

This PR was tested in provider-aws by using the S3-Bucket resource. Firstly, the commit id of this PR was used to consume the latest changes. And a custom `ExternalTagsFieldName` configuration was added for this resource. Then create, update and delete operations were successfully tested.

[contribution process]: https://git.io/fj2m9
