### PR TITLE
Conversion: Default to string as element type

### DIFF
--- a/pkg/types/conversion/conversion.go
+++ b/pkg/types/conversion/conversion.go
@@ -85,7 +85,9 @@ func toV2Schema(v1sch *schema.Schema) *schemav2.Schema {
 		case *schema.Resource:
 			v2sch.Elem = toV2Resource(et)
 		default:
-			panic("element type should be either schema.Resource or schema.Schema")
+			// Note(turkenh): We are defaulting to "String" as element type when
+			// it is not explicitly provided as element type of a collection.
+			v2sch.Elem = schemav2.TypeString
 		}
 	case schema.TypeInvalid:
 		panic(errors.Errorf("invalid schema type %s", v1sch.Type.String()))


### PR DESCRIPTION
### Description of your changes

There could be some collection types which do not set types of their elements explicitly and we found out assuming `String` in that case is the right way to go. We have implemented this in [type builder](https://github.com/crossplane/terrajet/pull/182) but didn't follow same in conversion for resources using v1 sdk.

This PR fixes the same issue in conversion package.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

With [provider rancher](https://registry.terraform.io/providers/rancher/rancher2/latest/docs/resources/catalog) which uses v1 sdk.

[contribution process]: https://git.io/fj2m9
