### PR TITLE
Add Sergen as a maintainer

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -8,3 +8,4 @@ In alphabetical order:
 * Alper Rifat Uluçınar <alper@upbound.io> ([ulucinar](https://github.com/ulucinar))
 * Hasan Türken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
 * Muvaffak Onuş <monus@upbound.io> ([muvaf](https://github.com/muvaf))
+* Sergen Yalçın <sergen@upbound.io> ([sergenyalcin](https://github.com/sergenyalcin))


### PR DESCRIPTION
### Description of your changes

Proposing to add @sergenyalcin as a maintainer given he already did some valuable [contributions](https://github.com/crossplane/terrajet/pulls?q=is%3Apr+author%3Asergenyalcin+is%3Aclosed) to Terrajet.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
