### PR TITLE
Support for map[string]*string as sensitive fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/json-iterator/go v1.1.11
-	github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32
+	github.com/muvaf/typewriter v0.0.0-20220131201631-921e94e8e8d7
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/afero v1.6.0
 	golang.org/x/tools v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -501,8 +501,8 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32 h1:yBQlHXLeUJL3TWVmzup5uT3wG5FLxhiTAiTsmNVocys=
-github.com/muvaf/typewriter v0.0.0-20210910160850-80e49fe1eb32/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
+github.com/muvaf/typewriter v0.0.0-20220131201631-921e94e8e8d7 h1:CxRHKnh1YJXgNKxcos9rrKL6AcmOl1AS/fygmxFDzh4=
+github.com/muvaf/typewriter v0.0.0-20220131201631-921e94e8e8d7/go.mod h1:SAAdeMEiFXR8LcHffvIdiLI1w243DCH2DuHq7UrA5YQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=

--- a/pkg/resource/sensitive.go
+++ b/pkg/resource/sensitive.go
@@ -33,11 +33,13 @@ import (
 )
 
 const (
-	errCannotExpandWildcards          = "cannot expand wildcards"
-	errFmtCannotGetValueForFieldPath  = "cannot not get a value for fieldpath %q"
-	errFmtCannotGetStringForFieldPath = "cannot not get a string for fieldpath %q"
-	errFmtCannotGetSecretKeySelector  = "cannot get SecretKeySelector from xp resource for fieldpath %q"
-	errFmtCannotGetSecretValue        = "cannot get secret value for %v"
+	errCannotExpandWildcards               = "cannot expand wildcards"
+	errFmtCannotGetValueForFieldPath       = "cannot not get a value for fieldpath %q"
+	errFmtCannotGetStringForFieldPath      = "cannot not get a string for fieldpath %q"
+	errFmtCannotGetSecretKeySelector       = "cannot get SecretKeySelector from xp resource for fieldpath %q"
+	errFmtCannotGetSecretKeySelectorAsList = "cannot get SecretKeySelector list from xp resource for fieldpath %q"
+	errFmtCannotGetSecretKeySelectorAsMap  = "cannot get SecretKeySelector map from xp resource for fieldpath %q"
+	errFmtCannotGetSecretValue             = "cannot get secret value for %v"
 )
 
 const (
@@ -204,7 +206,7 @@ func GetSensitiveParameters(ctx context.Context, client SecretClient, from runti
 			case map[string]interface{}:
 				sel := &map[string]v1.SecretKeySelector{}
 				if err = pavedJSON.GetValueInto(expandedJSONPath, sel); err != nil {
-					return errors.Wrapf(err, errFmtCannotGetSecretKeySelector, expandedJSONPath)
+					return errors.Wrapf(err, errFmtCannotGetSecretKeySelectorAsMap, expandedJSONPath)
 				}
 				sensitives := make(map[string]interface{})
 				for key, value := range *sel {
@@ -220,7 +222,7 @@ func GetSensitiveParameters(ctx context.Context, client SecretClient, from runti
 			case []interface{}:
 				sel := &[]v1.SecretKeySelector{}
 				if err = pavedJSON.GetValueInto(expandedJSONPath, sel); err != nil {
-					return errors.Wrapf(err, errFmtCannotGetSecretKeySelector, expandedJSONPath)
+					return errors.Wrapf(err, errFmtCannotGetSecretKeySelectorAsList, expandedJSONPath)
 				}
 				var sensitives []interface{}
 				for _, s := range *sel {

--- a/pkg/types/builder_test.go
+++ b/pkg/types/builder_test.go
@@ -327,7 +327,7 @@ func TestBuild(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.Wrapf(fmt.Errorf(`got type %q for field %q, only types "string", "*string", []string and []*string supported as sensitive`, "*float64", "Key1"), "cannot build the Types"),
+				err: errors.Wrapf(fmt.Errorf(`got type %q for field %q, only types "string", "*string", []string, []*string, "map[string]string" and "map[string]*string" supported as sensitive`, "*float64", "Key1"), "cannot build the Types"),
 			},
 		},
 		"References": {


### PR DESCRIPTION
### Description of your changes

Fixes #208 

This PR provides support for `map[string]*string` as sensitive fields. In resource manifests, more than one secrets and more than one fields of secrets can be referred as input for sensitive values. Also, sensitive field outputs will be written to the connection secret.

Also, this PR consumes that the latest commit in the typewriter repo.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I have tested this PR by using the following example manifest:

```
apiVersion: containerinstance.azure.jet.crossplane.io/v1alpha1
kind: ContainerGroup
metadata:
  name: example-cg
spec:
  forProvider:
    name: example-cg
    location: East US
    resourceGroupNameRef:
      name: example
    ipAddressType: public
    dnsNameLabel: sergen-label
    osType: Linux
    container:
      - name: "hello-world"
        image: "mcr.microsoft.com/azuredocs/aci-helloworld:latest"
        cpu: 0.5
        memory: 1.5
        ports:
          - port: 443
            protocol: "TCP"
        secureEnvironmentVariablesSecretRef:
          key1:
            name: test-map
            namespace: default
            key: key1
  providerConfigRef:
    name: example
  writeConnectionSecretToRef:
    name: result-map
    namespace: default
```

The external resource was successfully created and the connection secret had the correct values.

[contribution process]: https://git.io/fj2m9
