### PR TITLE
controller: set async finished condition only if the resource is async

### DIFF
--- a/pkg/controller/external.go
+++ b/pkg/controller/external.go
@@ -139,7 +139,9 @@ func (e *external) Observe(ctx context.Context, mg xpresource.Managed) (managed.
 	// There might be a case where async operation is finished and the status
 	// update marking it as finished didn't go through. At this point, we are
 	// sure that there is no ongoing operation.
-	tr.SetConditions(resource.AsyncOperationFinishedCondition())
+	if e.config.UseAsync {
+		tr.SetConditions(resource.AsyncOperationFinishedCondition())
+	}
 
 	// No operation was in progress, our observation completed successfully, and
 	// we have an observation to consume.


### PR DESCRIPTION
### Description of your changes

Not critical, but this call makes that condition appear on the resource it's irrelevant for most resources.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
