### PR TITLE
Cli Schema Conversion Fixes & Set ConfigMode Attribute

### DIFF
--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -158,7 +158,10 @@ func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //no
 		case et.IsPrimitiveType():
 			elemType = &schemav2.Schema{Type: primitiveToV2SchemaType(et)}
 		case et.IsCollectionType():
-			elemType = collectionToV2SchemaType(et)
+			elemType = &schemav2.Schema{Type: collectionToV2SchemaType(et)}
+			if err := schemaV2TypeFromCtyType(et, elemType.(*schemav2.Schema)); err != nil {
+				return err
+			}
 		case et.IsObjectType():
 			res := &schemav2.Resource{}
 			res.Schema = make(map[string]*schemav2.Schema, len(et.AttributeTypes()))

--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -156,9 +156,17 @@ func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //no
 		et := typ.ElementType()
 		switch {
 		case et.IsPrimitiveType():
-			elemType = &schemav2.Schema{Type: primitiveToV2SchemaType(et)}
+			elemType = &schemav2.Schema{
+				Type:     primitiveToV2SchemaType(et),
+				Computed: schema.Computed,
+				Optional: schema.Optional,
+			}
 		case et.IsCollectionType():
-			elemType = &schemav2.Schema{Type: collectionToV2SchemaType(et)}
+			elemType = &schemav2.Schema{
+				Type:     collectionToV2SchemaType(et),
+				Computed: schema.Computed,
+				Optional: schema.Optional,
+			}
 			if err := schemaV2TypeFromCtyType(et, elemType.(*schemav2.Schema)); err != nil {
 				return err
 			}
@@ -166,12 +174,16 @@ func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //no
 			res := &schemav2.Resource{}
 			res.Schema = make(map[string]*schemav2.Schema, len(et.AttributeTypes()))
 			for key, attrTyp := range et.AttributeTypes() {
-				sch := &schemav2.Schema{}
-				if err := schemaV2TypeFromCtyType(attrTyp, sch); err != nil {
-					return err
+				sch := &schemav2.Schema{
+					Computed: schema.Computed,
+					Optional: schema.Optional,
 				}
 				if et.AttributeOptional(key) {
 					sch.Optional = true
+				}
+
+				if err := schemaV2TypeFromCtyType(attrTyp, sch); err != nil {
+					return err
 				}
 				res.Schema[key] = sch
 			}

--- a/pkg/types/conversion/tfjson/tfjson.go
+++ b/pkg/types/conversion/tfjson/tfjson.go
@@ -148,6 +148,8 @@ func tfJSONBlockTypeToV2Schema(nb *tfjson.SchemaBlockType) *schemav2.Schema { //
 }
 
 func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //nolint:gocyclo
+	configMode := schemav2.SchemaConfigModeAuto
+
 	switch {
 	case typ.IsPrimitiveType():
 		schema.Type = primitiveToV2SchemaType(typ)
@@ -171,6 +173,7 @@ func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //no
 				return err
 			}
 		case et.IsObjectType():
+			configMode = schemav2.SchemaConfigModeAttr
 			res := &schemav2.Resource{}
 			res.Schema = make(map[string]*schemav2.Schema, len(et.AttributeTypes()))
 			for key, attrTyp := range et.AttributeTypes() {
@@ -191,6 +194,7 @@ func schemaV2TypeFromCtyType(typ cty.Type, schema *schemav2.Schema) error { //no
 		default:
 			return errors.Errorf("unexpected cty.Type %s", typ.GoString())
 		}
+		schema.ConfigMode = configMode
 		schema.Type = collectionToV2SchemaType(typ)
 		schema.Elem = elemType
 	case typ.IsTupleType():


### PR DESCRIPTION
### Description of your changes

This PR fixes some issues with converting schema of nested fields from CLI to SDK. It also sets `ConfigMode` parameter which is planned to be used in #244 to fix #232.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Using provider-jet-aws from [this branch](https://github.com/turkenh/provider-jet-aws/tree/config-as-block).

1. Generate with `make generate`.
2. ~~Ensure that ConfigMode attribute properly set.~~
3. Ensure that new schema generated same as before using changes in #244  

[contribution process]: https://git.io/fj2m9
