### PR TITLE
Generate a single zz_generated.terraformed.go file for the whole group

### DIFF
--- a/pkg/pipeline/run.go
+++ b/pkg/pipeline/run.go
@@ -28,6 +28,11 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 )
 
+type terraformedInput struct {
+	*config.Resource
+	ParametersTypeName string
+}
+
 // Run runs the Terrajet code generation pipelines.
 func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 	// Note(turkenh): nolint reasoning - this is the main function of the code
@@ -65,7 +70,7 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 	count := 0
 	for group, versions := range resourcesGroups {
 		for version, resources := range versions {
-			tfResources := make(map[*config.Resource]string)
+			var tfResources []*terraformedInput
 			versionGen := NewVersionGenerator(rootDir, pc.ModulePath, group, version)
 			crdGen := NewCRDGenerator(versionGen.Package(), rootDir, pc.ShortName, group, version)
 			tfGen := NewTerraformedGenerator(versionGen.Package(), rootDir, group, version)
@@ -76,7 +81,10 @@ func Run(pc *config.Provider, rootDir string) { // nolint:gocyclo
 				if err != nil {
 					panic(errors.Wrapf(err, "cannot generate crd for resource %s", name))
 				}
-				tfResources[resources[name]] = paramTypeName
+				tfResources = append(tfResources, &terraformedInput{
+					Resource:           resources[name],
+					ParametersTypeName: paramTypeName,
+				})
 				ctrlPkgPath, err := ctrlGen.Generate(resources[name], versionGen.Package().Path())
 				if err != nil {
 					panic(errors.Wrapf(err, "cannot generate controller for resource %s", name))

--- a/pkg/pipeline/templates/terraformed.go.tmpl
+++ b/pkg/pipeline/templates/terraformed.go.tmpl
@@ -2,7 +2,7 @@
 
 {{ .GenStatement }}
 
-package {{ .CRD.APIVersion }}
+package {{ .APIVersion }}
 
 import (
 	"github.com/pkg/errors"
@@ -11,84 +11,85 @@ import (
 	"github.com/crossplane/terrajet/pkg/resource/json"
 	{{ .Imports }}
 )
-
-// GetTerraformResourceType returns Terraform resource type for this {{ .CRD.Kind }}
-func (mg *{{ .CRD.Kind }}) GetTerraformResourceType() string {
-	return "{{ .Terraform.ResourceType }}"
-}
-
-// GetConnectionDetailsMapping for this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) GetConnectionDetailsMapping() map[string]string {
-  {{- if .Sensitive.Fields }}
-  return map[string]string{ {{range $k, $v := .Sensitive.Fields}}"{{ $k }}": "{{ $v}}", {{end}} }
-  {{- else }}
-  return nil
-  {{- end }}
-}
-
-// GetObservation of this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) GetObservation() (map[string]interface{}, error) {
-	o, err := json.TFParser.Marshal(tr.Status.AtProvider)
-	if err != nil {
-		return nil, err
-	}
-	base := map[string]interface{}{}
-	return base, json.TFParser.Unmarshal(o, &base)
-}
-
-// SetObservation for this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]interface{}) error {
-	p, err := json.TFParser.Marshal(obs)
-	if err != nil {
-		return err
-	}
-	return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
-}
-
-// GetID returns ID of underlying Terraform resource of this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) GetID() string {
-    if tr.Status.AtProvider.ID == nil {
-        return ""
+{{ range .Resources }}
+    // GetTerraformResourceType returns Terraform resource type for this {{ .CRD.Kind }}
+    func (mg *{{ .CRD.Kind }}) GetTerraformResourceType() string {
+        return "{{ .Terraform.ResourceType }}"
     }
-    return *tr.Status.AtProvider.ID
-}
 
-// GetParameters of this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
-	p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
-	if err != nil {
-		return nil, err
-	}
-	base := map[string]interface{}{}
-	return base, json.TFParser.Unmarshal(p, &base)
-}
+    // GetConnectionDetailsMapping for this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) GetConnectionDetailsMapping() map[string]string {
+      {{- if .Sensitive.Fields }}
+      return map[string]string{ {{range $k, $v := .Sensitive.Fields}}"{{ $k }}": "{{ $v}}", {{end}} }
+      {{- else }}
+      return nil
+      {{- end }}
+    }
 
-// SetParameters for this {{ .CRD.Kind }}
-func (tr *{{ .CRD.Kind }}) SetParameters(params map[string]interface{}) error {
-	p, err := json.TFParser.Marshal(params)
-	if err != nil {
-		return err
-	}
-	return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
-}
+    // GetObservation of this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) GetObservation() (map[string]interface{}, error) {
+        o, err := json.TFParser.Marshal(tr.Status.AtProvider)
+        if err != nil {
+            return nil, err
+        }
+        base := map[string]interface{}{}
+        return base, json.TFParser.Unmarshal(o, &base)
+    }
 
-// LateInitialize this {{ .CRD.Kind }} using its observed tfState.
-// returns True if there are any spec changes for the resource.
-func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
-	params := &{{ .CRD.ParametersTypeName }}{}
-	if err := json.TFParser.Unmarshal(attrs, params); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
-	}
-	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
-	{{ range .LateInitializer.IgnoredFields -}}
-	    opts = append(opts, resource.WithNameFilter("{{ . }}"))
-	{{ end }}
+    // SetObservation for this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) SetObservation(obs map[string]interface{}) error {
+        p, err := json.TFParser.Marshal(obs)
+        if err != nil {
+            return err
+        }
+        return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
+    }
 
-	li := resource.NewGenericLateInitializer(opts...)
-	return li.LateInitialize(&tr.Spec.ForProvider, params)
-}
+    // GetID returns ID of underlying Terraform resource of this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) GetID() string {
+        if tr.Status.AtProvider.ID == nil {
+            return ""
+        }
+        return *tr.Status.AtProvider.ID
+    }
 
-// GetTerraformSchemaVersion returns the associated Terraform schema version
-func (tr *{{ .CRD.Kind }}) GetTerraformSchemaVersion() int {
-    return {{ .Terraform.SchemaVersion }}
-}
+    // GetParameters of this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) GetParameters() (map[string]interface{}, error) {
+        p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
+        if err != nil {
+            return nil, err
+        }
+        base := map[string]interface{}{}
+        return base, json.TFParser.Unmarshal(p, &base)
+    }
+
+    // SetParameters for this {{ .CRD.Kind }}
+    func (tr *{{ .CRD.Kind }}) SetParameters(params map[string]interface{}) error {
+        p, err := json.TFParser.Marshal(params)
+        if err != nil {
+            return err
+        }
+        return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
+    }
+
+    // LateInitialize this {{ .CRD.Kind }} using its observed tfState.
+    // returns True if there are any spec changes for the resource.
+    func (tr *{{ .CRD.Kind }}) LateInitialize(attrs []byte) (bool, error) {
+        params := &{{ .CRD.ParametersTypeName }}{}
+        if err := json.TFParser.Unmarshal(attrs, params); err != nil {
+            return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
+        }
+        opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+        {{ range .LateInitializer.IgnoredFields -}}
+            opts = append(opts, resource.WithNameFilter("{{ . }}"))
+        {{ end }}
+
+        li := resource.NewGenericLateInitializer(opts...)
+        return li.LateInitialize(&tr.Spec.ForProvider, params)
+    }
+
+    // GetTerraformSchemaVersion returns the associated Terraform schema version
+    func (tr *{{ .CRD.Kind }}) GetTerraformSchemaVersion() int {
+        return {{ .Terraform.SchemaVersion }}
+    }
+{{ end }}


### PR DESCRIPTION
### Description of your changes

Fixes #43

This PR generates a single `terraformed.go` file for the whole API group. For example in provider-jet-azure we have containerservice/v1alpha2 API group. Now we have two resources in this API group and also we have two `terraformed.go` files: 

- `apis/containerservice/v1alpha2/zz_kubernetescluster_terraformed.go`
- `apis/containerservice/v1alpha2/zz_kubernetesclusternodepool_terraformed.go`

With this PR, we will generate a single `zz_generated.terraformed.go` for an API group.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

- Run make generate for provider-jet-azure and ensured that a single zz_generated.terraformed.go file is generated for the whole group.

[contribution process]: https://git.io/fj2m9
