### PR TITLE
Fix sensitive path mapping

### DIFF
--- a/pkg/types/builder.go
+++ b/pkg/types/builder.go
@@ -119,7 +119,7 @@ func (g *Builder) buildResource(res *schema.Resource, cfg *config.Resource, tfPa
 		// Terraform paths, e.g. { "lifecycle_rule", "*", "transition", "*", "days" } for https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#lifecycle_rule
 		tfPaths := append(tfPath, fieldName.Snake)
 		// Crossplane paths, e.g. {"lifecycleRule", "*", "transition", "*", "days"}
-		xpPaths := append(xpPath, fieldName.LowerCamel)
+		xpPaths := append(xpPath, fieldName.LowerCamelComputed)
 		// Canonical paths, e.g. {"LifecycleRule", "Transition", "Days"}
 		cnPaths := append(names[1:], fieldName.Camel)
 


### PR DESCRIPTION
### Description of your changes

We incorrectly used `fieldName.LowerCamel` in sensitive field mapping which takes acronyms [here](https://github.com/crossplane/terrajet/blob/main/pkg/types/name/name.go#L104) into account. However, we should use `fieldName.LowerCamelComputed` instead since we don't use acronyms with fields names.

Fixes #251

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Using provider-jet-vault, run make generate.

[contribution process]: https://git.io/fj2m9
