### PR TITLE
Update configuration doc for AdditionalConnectionDetailsFn

### DIFF
--- a/docs/configuring-a-resource.md
+++ b/docs/configuring-a-resource.md
@@ -378,17 +378,15 @@ respectively. To see them with more common keys, i.e. `aws_access_key_id` and
 ```go
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("aws_iam_access_key", func(r *config.Resource) {
-		r.Sensitive = config.Sensitive{
-			AdditionalConnectionDetailsFn: func(attr map[string]interface{}) (map[string][]byte, error) {
-				conn := map[string][]byte{}
-				if a, ok := attr["id"].(string); ok {
-					conn["aws_access_key_id"] = []byte(a)
-				}
-				if a, ok := attr["secret"].(string); ok {
-					conn["aws_secret_access_key"] = []byte(a)
-				}
-				return conn, nil
-			},
+		r.Sensitive.AdditionalConnectionDetailsFn = func(attr map[string]interface{}) (map[string][]byte, error) {
+			conn := map[string][]byte{}
+			if a, ok := attr["id"].(string); ok {
+				conn["aws_access_key_id"] = []byte(a)
+			}
+			if a, ok := attr["secret"].(string); ok {
+				conn["aws_secret_access_key"] = []byte(a)
+			}
+			return conn, nil
 		}
 	})
 }


### PR DESCRIPTION
### Description of your changes

This is a nitpicky documentation fix that I noticed while reviewing https://github.com/crossplane-contrib/provider-jet-gcp/pull/48.

We don't need to initialize a new `config.Sensitive` struct while configuring `AdditionalConnectionDetailsFn` given it is not a pointer type.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Run `make reviewable` in provider-jet-aws after following that step.

[contribution process]: https://git.io/fj2m9
