### PR TITLE
Allow late-initialization before a Terraform apply

### DIFF
--- a/pkg/controller/external_test.go
+++ b/pkg/controller/external_test.go
@@ -21,12 +21,14 @@ import (
 	"testing"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	xpmeta "github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
 	xpfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/terrajet/pkg/config"
@@ -274,6 +276,11 @@ func TestObserve(t *testing.T) {
 			args: args{
 				obj: &fake.Terraformed{
 					Managed: xpfake.Managed{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								xpmeta.AnnotationKeyExternalName: "some-id",
+							},
+						},
 						ConditionedStatus: xpv1.ConditionedStatus{
 							Conditions: []xpv1.Condition{xpv1.Available()},
 						},


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Due to an optimization related with the readiness of `Terraformed` resources, in certain circumstances, we never have a chance to do a late initialization before we run a Terraform apply. However, as revealed in https://github.com/crossplane-contrib/provider-jet-azure/issues/139, for certain resources and their configurations, it helps to do an early late-initialize before a Terraform plan. If certain optional fields are not set, a Terraform plan fails because we use the `prevent_destroy` lifecycle meta-argument. 

Categorically, we can also claim that these are upstream Terraform issues (e.g., one is [here](https://github.com/hashicorp/terraform-provider-azurerm/issues/8297)) but with this PR, we can both solve such cases and also preserve the readiness optimization we already have. For some context, please refer to https://github.com/crossplane-contrib/provider-jet-azure/issues/139 and please also see https://github.com/crossplane-contrib/provider-jet-azure/issues/139#issuecomment-1067630912. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested via consuming this PR in `provider-jet-azure` in the context of https://github.com/crossplane-contrib/provider-jet-azure/issues/139. 

[contribution process]: https://git.io/fj2m9
