### PR TITLE
Start shared native provider using a magic cookie

### DIFF
--- a/pkg/terraform/provider_runner.go
+++ b/pkg/terraform/provider_runner.go
@@ -18,6 +18,8 @@ package terraform
 
 import (
 	"bufio"
+	"fmt"
+	"os"
 	"regexp"
 	"sync"
 	"time"
@@ -33,9 +35,13 @@ const (
 	errFmtTimeout = "timed out after %v while waiting for the reattach configuration string"
 
 	// an example value would be: '{"registry.terraform.io/hashicorp/aws": {"Protocol": "grpc", "ProtocolVersion":5, "Pid":... "Addr":{"Network": "unix","String": "..."}}}'
-	envReattachConfig = "TF_REATTACH_PROVIDERS"
-	regexReattachLine = envReattachConfig + `='(.*)'`
-	reattachTimeout   = 1 * time.Minute
+	fmtReattachEnv     = `{"%s":{"Protocol":"grpc","ProtocolVersion":%d,"Pid":%d,"Test": true,"Addr":{"Network": "unix","String": "%s"}}}`
+	fmtSetEnv          = "%s=%s"
+	envReattachConfig  = "TF_REATTACH_PROVIDERS"
+	envMagicCookie     = "TF_PLUGIN_MAGIC_COOKIE"
+	defaultMagicCookie = "d602bf8f470bc67ca7faa0386276bbdd4330efaf76d1a219cb4d6991ca9872b2"
+	regexReattachLine  = `.*unix\|(.*)\|grpc.*`
+	reattachTimeout    = 1 * time.Minute
 )
 
 // ProviderRunner is the interface for running
@@ -64,6 +70,9 @@ type SharedProvider struct {
 	nativeProviderPath string
 	nativeProviderArgs []string
 	reattachConfig     string
+	nativeProviderName string
+	protocolVersion    int
+	pluginMagicCookie  string
 	logger             logging.Logger
 	executor           exec.Interface
 	clock              clock.Clock
@@ -87,12 +96,23 @@ func WithNativeProviderExecutor(e exec.Interface) SharedGRPCRunnerOption {
 	}
 }
 
+// WithNativeProviderMagicCookie sets the magic cookie for
+// the native provider plugin to run.
+func WithNativeProviderMagicCookie(cookie string) SharedGRPCRunnerOption {
+	return func(sr *SharedProvider) {
+		sr.pluginMagicCookie = cookie
+	}
+}
+
 // NewSharedProvider instantiates a SharedProvider with an
 // OS executor using the supplied logger
-func NewSharedProvider(l logging.Logger, nativeProviderPath string, opts ...SharedGRPCRunnerOption) *SharedProvider {
+func NewSharedProvider(l logging.Logger, nativeProviderPath, nativeProviderName string, protocolVersion int, opts ...SharedGRPCRunnerOption) *SharedProvider {
 	sr := &SharedProvider{
 		logger:             l,
 		nativeProviderPath: nativeProviderPath,
+		nativeProviderName: nativeProviderName,
+		protocolVersion:    protocolVersion,
+		pluginMagicCookie:  defaultMagicCookie,
 		executor:           exec.New(),
 		clock:              clock.RealClock{},
 		mu:                 &sync.Mutex{},
@@ -133,6 +153,7 @@ func (sr *SharedProvider) Start() (string, error) { //nolint:gocyclo
 		}()
 		//#nosec G204 no user input
 		cmd := sr.executor.Command(sr.nativeProviderPath, sr.nativeProviderArgs...)
+		cmd.SetEnv(append(os.Environ(), fmt.Sprintf(fmtSetEnv, envMagicCookie, sr.pluginMagicCookie)))
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
 			errCh <- err
@@ -149,7 +170,7 @@ func (sr *SharedProvider) Start() (string, error) { //nolint:gocyclo
 			if matches == nil {
 				continue
 			}
-			reattachCh <- matches[1]
+			reattachCh <- fmt.Sprintf(fmtReattachEnv, sr.nativeProviderName, sr.protocolVersion, os.Getpid(), matches[1])
 			break
 		}
 		if err := cmd.Wait(); err != nil {

--- a/pkg/terraform/provider_runner_test.go
+++ b/pkg/terraform/provider_runner_test.go
@@ -38,7 +38,6 @@ import (
 func TestStartSharedServer(t *testing.T) {
 	testPath := "path"
 	testName := "provider-test"
-	testProtocol := 5
 	testArgs := []string{"arg1", "arg2"}
 	testReattachConfig1 := `1|5|unix|test1|grpc|`
 	testReattachConfig2 := `1|5|unix|test2|grpc|`
@@ -61,7 +60,7 @@ func TestStartSharedServer(t *testing.T) {
 		},
 		"SuccessfullyStarted": {
 			args: args{
-				runner: NewSharedProvider(logging.NewNopLogger(), testPath, testName, testProtocol, WithNativeProviderArgs(testArgs...),
+				runner: NewSharedProvider(logging.NewNopLogger(), testPath, testName, WithNativeProviderArgs(testArgs...),
 					WithNativeProviderExecutor(newExecutorWithStoutPipe(testReattachConfig1, nil))),
 			},
 			want: want{
@@ -84,7 +83,7 @@ func TestStartSharedServer(t *testing.T) {
 		},
 		"NativeProviderError": {
 			args: args{
-				runner: NewSharedProvider(logging.NewNopLogger(), testPath, testName, testProtocol,
+				runner: NewSharedProvider(logging.NewNopLogger(), testPath, testName,
 					WithNativeProviderExecutor(newExecutorWithStoutPipe(testReattachConfig1, testErr))),
 			},
 			want: want{

--- a/pkg/terraform/provider_runner_test.go
+++ b/pkg/terraform/provider_runner_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package terraform
 
 import (
+	"fmt"
 	"io"
+	"os"
 	"reflect"
 	"strings"
 	"sync"
@@ -35,9 +37,11 @@ import (
 
 func TestStartSharedServer(t *testing.T) {
 	testPath := "path"
+	testName := "provider-test"
+	testProtocol := 5
 	testArgs := []string{"arg1", "arg2"}
-	testReattachConfig1 := `TF_REATTACH_PROVIDERS='test1'`
-	testReattachConfig2 := `TF_REATTACH_PROVIDERS='test2'`
+	testReattachConfig1 := `1|5|unix|test1|grpc|`
+	testReattachConfig2 := `1|5|unix|test2|grpc|`
 	testErr := errors.New("boom")
 	type args struct {
 		runner ProviderRunner
@@ -57,11 +61,11 @@ func TestStartSharedServer(t *testing.T) {
 		},
 		"SuccessfullyStarted": {
 			args: args{
-				runner: NewSharedProvider(logging.NewNopLogger(), testPath, WithNativeProviderArgs(testArgs...),
+				runner: NewSharedProvider(logging.NewNopLogger(), testPath, testName, testProtocol, WithNativeProviderArgs(testArgs...),
 					WithNativeProviderExecutor(newExecutorWithStoutPipe(testReattachConfig1, nil))),
 			},
 			want: want{
-				reattachConfig: "test1",
+				reattachConfig: fmt.Sprintf(`{"provider-test":{"Protocol":"grpc","ProtocolVersion":5,"Pid":%d,"Test": true,"Addr":{"Network": "unix","String": "test1"}}}`, os.Getpid()),
 			},
 		},
 		"AlreadyRunning": {
@@ -80,7 +84,7 @@ func TestStartSharedServer(t *testing.T) {
 		},
 		"NativeProviderError": {
 			args: args{
-				runner: NewSharedProvider(logging.NewNopLogger(), testPath,
+				runner: NewSharedProvider(logging.NewNopLogger(), testPath, testName, testProtocol,
 					WithNativeProviderExecutor(newExecutorWithStoutPipe(testReattachConfig1, testErr))),
 			},
 			want: want{


### PR DESCRIPTION
<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Terrajet issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
It turns out that we cannot run the Terraform GCP provider as a shared server like we do for the AWS and Azure providers (by invoking the plugin binary with certain command-line options). We have identified another way in which we set a cookie in the native provider's environment to keep it running as a shared server. This PR switches to this method in the `SharedProvider` implementation.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
- Successfully tested with `provider-jet-aws` both locally & in-cluster with a provider package by provisioning and destroying a VPC. Related PR: https://github.com/crossplane-contrib/provider-jet-aws/pull/182
- Successfully tested with `provider-jet-gcp` both locally & in-cluster with a provider package by provisioning and destroying a ServiceAccount. Related PR: https://github.com/crossplane-contrib/provider-jet-gcp/pull/58
- Successfully tested with `provider-jet-azure` both locally & in-cluster with a provider package by importing a ResourceGroup. Related PR: https://github.com/crossplane-contrib/provider-jet-azure/pull/179


[contribution process]: https://git.io/fj2m9
