### PR TITLE
Fix syntax errors in resource configuration example

### DIFF
--- a/docs/configuring-a-resource.md
+++ b/docs/configuring-a-resource.md
@@ -142,11 +142,11 @@ import (
         r.ExternalName = config.NameAsIdentifier
         r.ExternalName.SetIdentifierArgumentFn = func(base map[string]interface{}, externalName string) {
             base["bucket"] = externalName
-        },
-        r.ExternalName.OmittedFields: []string{
+        }
+        r.ExternalName.OmittedFields = []string{
             "bucket",
             "bucket_prefix",
-        },
+        }
 		...
     }
 ```

--- a/docs/configuring-a-resource.md
+++ b/docs/configuring-a-resource.md
@@ -712,4 +712,4 @@ So, an interface must be passed to the related configuration field for adding in
 [NewInitializerFn]: https://github.com/crossplane/terrajet/blob/ae78a0a4c438f01717002e00fac761524aa6e951/pkg/config/resource.go#L207
 [crossplane-runtime]: https://github.com/crossplane/crossplane-runtime/blob/428b7c3903756bb0dcf5330f40298e1fa0c34301/pkg/reconciler/managed/reconciler.go#L138
 [some external labels]: https://github.com/crossplane/crossplane-runtime/blob/428b7c3903756bb0dcf5330f40298e1fa0c34301/pkg/resource/resource.go#L397
-[tagging convention]: https://github.com/crossplane/crossplane/blob/master/design/one-pager-managed-resource-api-design.md#external-resource-labeling
+[tagging convention]: https://github.com/crossplane/crossplane/blob/60c7df9/design/one-pager-managed-resource-api-design.md#external-resource-labeling


### PR DESCRIPTION

<!--
Thank you for helping to improve Terrajet!

Please read through https://git.io/fj2m9 if this is your first time opening a
Terrajet pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->


### Description of your changes

Apparently it was a quick copy-paste from `pkg/config/defaults.go`
where related config is a Struct instead of direct assignment.

This commit fixes the example to contain valid syntax.

Signed-off-by: Yury Tsarev <yury@upbound.io>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

Simple code validation check 

[contribution process]: https://git.io/fj2m9
